### PR TITLE
CameraAPI1を使う条件をL未満に変更

### DIFF
--- a/com.moneyforward.cameracompat/src/main/java/com/moneyforward/cameracompat/CameraCompatFragmentFactory.java
+++ b/com.moneyforward.cameracompat/src/main/java/com/moneyforward/cameracompat/CameraCompatFragmentFactory.java
@@ -14,7 +14,7 @@ public class CameraCompatFragmentFactory {
     public static CameraCompatFragment getInstance() {
         CameraCompatFragment fragment;
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             fragment = Camera1Fragment.newInstance();
         } else {
             fragment = Camera2Fragment.newInstance();


### PR DESCRIPTION
Camera2FragmentのTargetAPIは`LOLIPOP`になっているようなので、
Camera1、Camera2の条件も`LOLIPOP`未満/以前にすべきように思われます。