### PR TITLE
Fix NPE crash on unlock focus

### DIFF
--- a/com.moneyforward.cameracompat/src/main/java/com/moneyforward/cameracompat/camera2/Camera2Fragment.java
+++ b/com.moneyforward.cameracompat/src/main/java/com/moneyforward/cameracompat/camera2/Camera2Fragment.java
@@ -802,12 +802,15 @@ public class Camera2Fragment extends Fragment implements CameraCompatFragment, F
                     CameraMetadata.CONTROL_AF_TRIGGER_CANCEL);
             previewRequestBuilder.set(CaptureRequest.CONTROL_AE_MODE,
                     CaptureRequest.CONTROL_AE_MODE_ON);
-            captureSession.capture(previewRequestBuilder.build(), captureCallback,
-                    backgroundHandler);
+            if (captureSession != null) {
+                captureSession.capture(previewRequestBuilder.build(), captureCallback,
+                        backgroundHandler);
+                captureSession.setRepeatingRequest(previewRequest, captureCallback,
+                        backgroundHandler);
+            }
             // After this, the camera will go back to the normal state of preview.
             cameraState = CameraState.STATE_PREVIEW;
-            captureSession.setRepeatingRequest(previewRequest, captureCallback,
-                    backgroundHandler);
+
         } catch (CameraAccessException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
### 問題
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'int android.hardware.camera2.CameraCaptureSession.capture(android.hardware.camera2.CaptureRequest, android.hardware.camera2.CameraCaptureSession$CaptureCallback, android.os.Handler)' on a null object reference
       at com.moneyforward.cameracompat.camera2.Camera2Fragment.unlockFocus(Camera2Fragment.java:805)
       at com.moneyforward.cameracompat.camera2.Camera2Fragment.access$1900(Camera2Fragment.java:66)
       at com.moneyforward.cameracompat.camera2.Camera2Fragment$8.onCaptureCompleted(Camera2Fragment.java:784)
       at java.lang.reflect.Method.invoke(Method.java)
       at android.hardware.camera2.dispatch.InvokeDispatcher.dispatch(InvokeDispatcher.java:39)
       at android.hardware.camera2.dispatch.HandlerDispatcher$1.run(HandlerDispatcher.java:65)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:224)
       at android.os.HandlerThread.run(HandlerThread.java:61)
```

Camrea2Fragmentで`unlockFocus`と`closeCamera`の処理順によっては
`captureSession`が`null`になっている場合があり、
NPEでクラッシュしてしまう。

### 対応
nullチェック追加